### PR TITLE
Switching to a Generic Controller

### DIFF
--- a/config/crd/bases/apigateway.awsctrl.io_accounts.yaml
+++ b/config/crd/bases/apigateway.awsctrl.io_accounts.yaml
@@ -3,6 +3,8 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.2.2
   creationTimestamp: null
   name: accounts.apigateway.awsctrl.io
 spec:

--- a/config/crd/bases/cloudformation.awsctrl.io_stacks.yaml
+++ b/config/crd/bases/cloudformation.awsctrl.io_stacks.yaml
@@ -3,6 +3,8 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.2.2
   creationTimestamp: null
   name: stacks.cloudformation.awsctrl.io
 spec:

--- a/config/crd/bases/self.awsctrl.io_configs.yaml
+++ b/config/crd/bases/self.awsctrl.io_configs.yaml
@@ -3,6 +3,8 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.2.2
   creationTimestamp: null
   name: configs.self.awsctrl.io
 spec:

--- a/config/samples/apigateway_v1alpha1_account.yaml
+++ b/config/samples/apigateway_v1alpha1_account.yaml
@@ -3,3 +3,4 @@ kind: Account
 metadata:
   name: account-sample
 spec: {}
+  # cloudWatchRoleRef: arn:aws:iam::xxxxxxxxxxxx:role/apig-role

--- a/controllers/apigateway/account_controller.go
+++ b/controllers/apigateway/account_controller.go
@@ -17,25 +17,21 @@ package apigateway
 
 import (
 	"context"
-	"strings"
 	"time"
 
 	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
 
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	apigatewayv1alpha1 "awsctrl.io/apis/apigateway/v1alpha1"
 	cloudformationv1alpha1 "awsctrl.io/apis/cloudformation/v1alpha1"
-	metav1alpha1 "awsctrl.io/apis/meta/v1alpha1"
+	"awsctrl.io/controllers/generic"
 	controllerutils "awsctrl.io/controllers/utils"
-	cfnencoder "awsctrl.io/encoding/cloudformation"
 )
 
 var (
@@ -62,37 +58,27 @@ type AccountReconciler struct {
 func (r *AccountReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	ctx := context.Background()
 	log := r.Log.WithValues("Account", req.NamespacedName)
-	waitDuration := time.Duration(2 * time.Second)
 
+	var err error
 	var instance apigatewayv1alpha1.Account
-	if err := r.Get(ctx, req.NamespacedName, &instance); err != nil {
+	if err = r.Get(ctx, req.NamespacedName, &instance); err != nil {
 		if errors.IsNotFound(err) {
 			return ctrl.Result{}, nil
 		}
 		return ctrl.Result{}, err
 	}
 
-	if instance.Spec.StackName == "" {
-		log.Info("Create CloudFormation Stack")
-		if err := r.addStack(ctx, &instance); err != nil {
-			return ctrl.Result{}, err
-		}
-
-		return ctrl.Result{RequeueAfter: waitDuration}, r.updateTemplateVersion(ctx, req.NamespacedName)
+	var cfncontroller generic.Generic
+	if cfncontroller, err = generic.New(r.Client, r.Scheme); err != nil {
+		return ctrl.Result{}, err
 	}
 
-	if controllerutils.IsStatusComplete(instance.Status.Status) &&
-		templateVersionChanged(&instance) {
-		log.Info("Update CloudFormation Stack")
-		if err := r.updateStack(ctx, &instance); err != nil {
-			return ctrl.Result{}, err
-		}
-
-		return ctrl.Result{}, r.updateTemplateVersion(ctx, req.NamespacedName)
+	var requeue time.Duration
+	if requeue, err = cfncontroller.Reconcile(ctx, log, &instance); err != nil {
+		return ctrl.Result{RequeueAfter: requeue}, err
 	}
 
-	log.Info("Update Status")
-	return reconcile.Result{}, r.updateStatus(ctx, &instance)
+	return ctrl.Result{}, nil
 }
 
 // SetupWithManager will setup the controller
@@ -116,105 +102,4 @@ func (r *AccountReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		For(&apigatewayv1alpha1.Account{}).
 		Owns(&cloudformationv1alpha1.Stack{}).
 		Complete(r)
-}
-
-func (r *AccountReconciler) addStack(ctx context.Context, instance *apigatewayv1alpha1.Account) error {
-	stack, err := r.newAccountStack(instance)
-	if err != nil {
-		return err
-	}
-
-	if err := r.Create(ctx, stack); err != nil {
-		return err
-	}
-
-	instanceCopy := instance.DeepCopy()
-	instanceCopy.Spec.StackName = stack.Name
-
-	return r.Update(ctx, instanceCopy)
-}
-
-func (r *AccountReconciler) updateStack(ctx context.Context, instance *apigatewayv1alpha1.Account) error {
-	params := map[string]string{}
-	cfnencoder.MarshalTypes(params, instance.Spec, "Parameter")
-
-	var stack cloudformationv1alpha1.Stack
-	if err := r.Get(ctx, types.NamespacedName{Name: instance.Spec.StackName, Namespace: instance.Namespace}, &stack); err != nil {
-		return err
-	}
-
-	stackCopy := stack.DeepCopy()
-	stackCopy.Spec.Parameters = params
-	stackCopy.Spec.TemplateBody = instance.GetTemplate()
-	stackCopy.Spec.CloudFormationMeta = metav1alpha1.CloudFormationMeta{
-		Region:                instance.Spec.Region,
-		NotificationARNs:      instance.Spec.NotificationARNs,
-		OnFailure:             instance.Spec.OnFailure,
-		Tags:                  instance.Spec.Tags,
-		TerminationProtection: instance.Spec.TerminationProtection,
-	}
-
-	return r.Update(ctx, stackCopy)
-}
-
-func (r *AccountReconciler) updateStatus(ctx context.Context, instance *apigatewayv1alpha1.Account) error {
-	var stack cloudformationv1alpha1.Stack
-	if err := r.Get(ctx, types.NamespacedName{Name: instance.Spec.StackName, Namespace: instance.Namespace}, &stack); err != nil {
-		return err
-	}
-
-	instance.Status.StatusMeta = *stack.Status.StatusMeta.DeepCopy()
-	return r.Status().Update(ctx, instance)
-}
-
-func (r *AccountReconciler) updateTemplateVersion(ctx context.Context, namespaceName types.NamespacedName) error {
-	var instance apigatewayv1alpha1.Account
-	if err := r.Get(ctx, namespaceName, &instance); err != nil {
-		return err
-	}
-	instanceCopy := instance.DeepCopy()
-
-	if len(instanceCopy.Labels) == 0 {
-		instanceCopy.Labels = map[string]string{}
-	}
-
-	instanceCopy.Labels[controllerutils.StackTemplateVersionLabel] = controllerutils.ComputeHash(instanceCopy.Spec)
-
-	return r.Update(ctx, instanceCopy)
-}
-
-func templateVersionChanged(instance *apigatewayv1alpha1.Account) bool {
-	return instance.Labels[controllerutils.StackTemplateVersionLabel] != controllerutils.ComputeHash(instance.Spec)
-}
-
-func stackName(name, namespace string) string {
-	return strings.Join([]string{"apigateway", "account", namespace, name}, "-")
-}
-
-func (r *AccountReconciler) newAccountStack(instance *apigatewayv1alpha1.Account) (*cloudformationv1alpha1.Stack, error) {
-	params := map[string]string{}
-	cfnencoder.MarshalTypes(params, instance.Spec, "Parameter")
-
-	stack := &cloudformationv1alpha1.Stack{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      stackName(instance.Name, instance.Namespace),
-			Namespace: instance.Namespace,
-		},
-		Spec: cloudformationv1alpha1.StackSpec{
-			CloudFormationMeta: metav1alpha1.CloudFormationMeta{
-				Region:                instance.Spec.Region,
-				NotificationARNs:      instance.Spec.NotificationARNs,
-				OnFailure:             instance.Spec.OnFailure,
-				Tags:                  instance.Spec.Tags,
-				TerminationProtection: instance.Spec.TerminationProtection,
-			},
-			Parameters:   params,
-			TemplateBody: instance.GetTemplate(),
-		},
-	}
-
-	if err := ctrl.SetControllerReference(instance, stack, r.Scheme); err != nil {
-		return nil, err
-	}
-	return stack, nil
 }

--- a/controllers/generic/generic.go
+++ b/controllers/generic/generic.go
@@ -1,0 +1,150 @@
+/*
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package generic implements the basic CFN backed controller functions
+package generic
+
+import (
+	"context"
+	"time"
+
+	"awsctrl.io/meta"
+	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	cloudformationv1alpha1 "awsctrl.io/apis/cloudformation/v1alpha1"
+	controllerutils "awsctrl.io/controllers/utils"
+)
+
+// Generic implements the functions for generic CloudFormation controllers
+type Generic interface {
+	Reconcile(context.Context, logr.Logger, meta.StackObject) (time.Duration, error)
+}
+
+type generic struct {
+	client.Client
+	Scheme *runtime.Scheme
+}
+
+// New configures a new controller
+func New(c client.Client, scheme *runtime.Scheme) (Generic, error) {
+	return &generic{
+		Client: c,
+		Scheme: scheme,
+	}, nil
+}
+
+func (r *generic) Reconcile(ctx context.Context, log logr.Logger, instance meta.StackObject) (time.Duration, error) {
+	requeueZero := time.Duration(0 * time.Second)
+	requeueLater := time.Duration(2 * time.Second)
+
+	if instance.GetStackName() == "" {
+		log.Info("Create CloudFormation Stack")
+		if err := r.addStack(ctx, instance); err != nil {
+			return requeueZero, err
+		}
+		return requeueLater, r.updateTemplateVersion(ctx, instance)
+	}
+
+	if controllerutils.IsStatusComplete(instance.GetStatus()) &&
+		instance.TemplateVersionChanged() {
+		log.Info("Update CloudFormation Stack")
+		if err := r.updateStack(ctx, instance); err != nil {
+			return requeueZero, err
+		}
+		return requeueLater, r.updateTemplateVersion(ctx, instance)
+	}
+
+	log.Info("Update Status")
+	return requeueZero, r.updateStatus(ctx, instance)
+}
+
+func (r *generic) addStack(ctx context.Context, instance meta.StackObject) error {
+	stack, err := r.newStack(instance)
+	if err != nil {
+		return err
+	}
+
+	if err := r.Create(ctx, stack); err != nil {
+		return err
+	}
+
+	instanceCopy := instance.DeepCopyObject().(meta.StackObject)
+	instanceCopy.SetStackName(stack.Name)
+
+	return r.Update(ctx, instanceCopy)
+}
+
+func (r *generic) updateStack(ctx context.Context, instance meta.StackObject) error {
+	var stack cloudformationv1alpha1.Stack
+	if err := r.Get(ctx, types.NamespacedName{Name: instance.GetStackName(), Namespace: instance.GetNamespace()}, &stack); err != nil {
+		return err
+	}
+
+	stackCopy := stack.DeepCopy()
+	stackCopy.Spec.Parameters = instance.GetParameters()
+	stackCopy.Spec.TemplateBody = instance.GetTemplate()
+	stackCopy.Spec.CloudFormationMeta = instance.GetCloudFormationMeta()
+
+	return r.Update(ctx, stackCopy)
+}
+
+func (r *generic) updateStatus(ctx context.Context, instance meta.StackObject) error {
+	var stack cloudformationv1alpha1.Stack
+	if err := r.Get(ctx, types.NamespacedName{Name: instance.GetStackName(), Namespace: instance.GetNamespace()}, &stack); err != nil {
+		return err
+	}
+
+	instance.SetStatus(stack.Status.StatusMeta.DeepCopy())
+	return r.Status().Update(ctx, instance)
+}
+
+func (r *generic) updateTemplateVersion(ctx context.Context, instance meta.StackObject) error {
+	nsn := types.NamespacedName{Namespace: instance.GetNamespace(), Name: instance.GetName()}
+
+	var newInstance = instance.DeepCopyObject()
+	if err := r.Get(ctx, nsn, newInstance); err != nil {
+		return err
+	}
+
+	instanceCopy := newInstance.DeepCopyObject().(meta.StackObject)
+	instanceCopy.SetTemplateVersionLabel()
+
+	return r.Update(ctx, instanceCopy)
+}
+
+func (r *generic) newStack(instance meta.StackObject) (*cloudformationv1alpha1.Stack, error) {
+	stack := &cloudformationv1alpha1.Stack{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      instance.GenerateStackName(),
+			Namespace: instance.GetNamespace(),
+		},
+		Spec: cloudformationv1alpha1.StackSpec{
+			CloudFormationMeta: instance.GetCloudFormationMeta(),
+			Parameters:         instance.GetParameters(),
+			TemplateBody:       instance.GetTemplate(),
+		},
+	}
+
+	if err := ctrl.SetControllerReference(instance, stack, r.Scheme); err != nil {
+		return nil, err
+	}
+	return stack, nil
+}

--- a/controllers/utils/utils.go
+++ b/controllers/utils/utils.go
@@ -33,7 +33,10 @@ var (
 )
 
 func IsStatusComplete(status metav1alpha1.ConditionStatus) bool {
-	return status == metav1alpha1.CreateCompleteStatus || status == metav1alpha1.UpdateCompleteStatus
+	return status == metav1alpha1.CreateCompleteStatus ||
+		status == metav1alpha1.UpdateCompleteStatus ||
+		status == metav1alpha1.UpdateRollbackCompleteStatus ||
+		status == metav1alpha1.RollbackCompleteStatus
 }
 
 // ContainsFinalizer will check if the finalizer exists

--- a/main.go
+++ b/main.go
@@ -77,7 +77,7 @@ func main() {
 
 	if err = (&self.ConfigReconciler{
 		Client:       mgr.GetClient(),
-		Log:          ctrl.Log.WithName("controllers").WithName("Self").WithName("Config"),
+		Log:          ctrl.Log.WithName("controllers").WithName("self").WithName("config"),
 		Scheme:       mgr.GetScheme(),
 		ConfigName:   configname,
 		PodNamespace: os.Getenv("POD_NAMESPACE"),
@@ -89,7 +89,7 @@ func main() {
 
 	if err = (&cloudformation.StackReconciler{
 		Client:       mgr.GetClient(),
-		Log:          ctrl.Log.WithName("controllers").WithName("Cloudformation").WithName("Stack"),
+		Log:          ctrl.Log.WithName("controllers").WithName("cloudformation").WithName("stack"),
 		Scheme:       mgr.GetScheme(),
 		ConfigName:   configname,
 		PodNamespace: os.Getenv("POD_NAMESPACE"),
@@ -102,7 +102,7 @@ func main() {
 
 	if err = (&apigateway.AccountReconciler{
 		Client: mgr.GetClient(),
-		Log:    ctrl.Log.WithName("controllers").WithName("Apigatway").WithName("Account"),
+		Log:    ctrl.Log.WithName("controllers").WithName("apigatway").WithName("account"),
 		Scheme: mgr.GetScheme(),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Account")

--- a/meta/meta.go
+++ b/meta/meta.go
@@ -16,8 +16,56 @@ limitations under the License.
 // Package meta contains meta helpers
 package meta
 
+import (
+	metav1alpha1 "awsctrl.io/apis/meta/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
 // StackObject defines defined functions for all stack objects
 type StackObject interface {
+	runtime.Object
+	metav1.Object
+
 	// GetNotificationARNs will return the list of Notifications
 	GetNotificationARNs() []string
+
+	// GetTemplate will return the JSON version of the CFN to use.
+	GetTemplate() string
+
+	// GenerateStackName will generate a stackName
+	GenerateStackName() string
+
+	// GetStackID will return stackID
+	GetStackID() string
+
+	// GetStackName will return stackName
+	GetStackName() string
+
+	// GetTemplateVersionLabel will return the template version label
+	GetTemplateVersionLabel() (string, bool)
+
+	// GetParameters will return the CFN Params
+	GetParameters() map[string]string
+
+	// GetCloudFormationMeta will return CFN meta object
+	GetCloudFormationMeta() metav1alpha1.CloudFormationMeta
+
+	// GetStatus will return the CFN Status
+	GetStatus() metav1alpha1.ConditionStatus
+
+	// SetStackID will put a stackID
+	SetStackID(string)
+
+	// SetStackName will put a stackName
+	SetStackName(string)
+
+	// SetTemplateVersionLabel will set the template version label
+	SetTemplateVersionLabel()
+
+	// TemplateVersionChanged will return if the template version has changed
+	TemplateVersionChanged() bool
+
+	// SetStatus will set status for object
+	SetStatus(*metav1alpha1.StatusMeta)
 }


### PR DESCRIPTION
This switches the apigateway controller to use a generic controller package using a `meta.StackObject` interface, also adds the funcs each `<resource>_types.go` needs to fullfil the interface.

This will make the code generation much easier when it starts to use the CloudFormation Resource Specification.